### PR TITLE
Bumped dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,15 +6,16 @@ plugins {
     id("org.jetbrains.kotlin.kapt")
     id("dagger.hilt.android.plugin")
     id("org.jlleitschuh.gradle.ktlint") version "11.1.0"
+    id("com.google.devtools.ksp").version("1.6.10-1.0.4")
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "de.entikore.cyclopenten"
         minSdk = 24
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
 
@@ -69,25 +70,25 @@ dependencies {
     val androidTestVersion = "1.5.0"
     val androidTestJunitVersion = "1.1.5"
     val archCoreVersion = "2.2.0"
-    val composeVersion = "1.4.1"
-    val coroutineVersion = "1.6.4"
+    val composeVersion = "1.4.3"
+    val coroutineVersion = "1.7.1"
     val espressoVersion = "3.5.1"
-    val hiltVersion = "2.45"
+    val hiltVersion = "2.46.1"
     val lifecycleVersion = "2.6.1"
-    val mockitoKotlinVersion = "4.1.0"
-    val moshiVersion = "1.14.0"
-    val navigationTestVersion = "2.5.3"
+    val mockitoKotlinVersion = "5.0.0"
+    val moshiVersion = "1.15.0"
+    val navigationTestVersion = "2.6.0"
     val roomVersion = "2.5.1"
 
     // App dependencies
     implementation("com.jakewharton.timber:timber:5.0.1")
     implementation("com.squareup.moshi:moshi:$moshiVersion")
     implementation("com.squareup.moshi:moshi-kotlin:$moshiVersion")
-    kapt("com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion")
+    ksp("com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion")
     implementation("com.google.code.gson:gson:2.10.1")
 
     // Architecture Components
-    implementation("androidx.core:core-ktx:1.10.0")
+    implementation("androidx.core:core-ktx:1.10.1")
     implementation("androidx.room:room-runtime:$roomVersion")
     kapt("androidx.room:room-compiler:$roomVersion")
     implementation("androidx.room:room-ktx:$roomVersion")
@@ -102,9 +103,9 @@ dependencies {
     implementation("androidx.hilt:hilt-navigation-compose:1.0.0")
 
     // Jetpack Compose
-    implementation("androidx.activity:activity-compose:1.7.0")
+    implementation("androidx.activity:activity-compose:1.7.2")
     implementation("androidx.compose.ui:ui:$composeVersion")
-    implementation("androidx.compose.runtime:runtime-livedata:1.5.0-alpha02")
+    implementation("androidx.compose.runtime:runtime-livedata:1.6.0-alpha01")
     implementation("androidx.compose.ui:ui-tooling-preview:$composeVersion")
     implementation("androidx.compose.material:material:$composeVersion")
     implementation("androidx.compose.material:material-icons-extended:$composeVersion")
@@ -116,12 +117,12 @@ dependencies {
     testImplementation("androidx.arch.core:core-testing:$archCoreVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutineVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutineVersion")
-    testImplementation("org.robolectric:robolectric:4.9.2")
+    testImplementation("org.robolectric:robolectric:4.10.3")
     testImplementation("androidx.navigation:navigation-testing:$navigationTestVersion")
     testImplementation("androidx.test.espresso:espresso-core:$espressoVersion")
     testImplementation("androidx.test.espresso:espresso-contrib:$espressoVersion")
     testImplementation("androidx.test.espresso:espresso-intents:$espressoVersion")
-    testImplementation("com.google.truth:truth:1.1.3")
+    testImplementation("com.google.truth:truth:1.1.5")
     testImplementation("androidx.compose.ui:ui-test-junit4:$composeVersion")
     testImplementation("org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion")
 
@@ -146,9 +147,9 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-contrib:$espressoVersion")
     androidTestImplementation("androidx.test.espresso:espresso-intents:$espressoVersion")
     androidTestImplementation("androidx.test.espresso.idling:idling-concurrent:$espressoVersion")
-    androidTestImplementation("org.robolectric:annotations:4.9.2")
+    androidTestImplementation("org.robolectric:annotations:4.10.3")
     implementation("androidx.test.espresso:espresso-idling-resource:$espressoVersion")
-    androidTestImplementation("org.mockito:mockito-android:5.1.1")
+    androidTestImplementation("org.mockito:mockito-android:5.4.0")
     androidTestImplementation("org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4:$composeVersion")
     debugImplementation("androidx.compose.ui:ui-test-manifest:$composeVersion")

--- a/app/src/test/java/de/entikore/cyclopenten/ui/screen/game/GameViewModelTest.kt
+++ b/app/src/test/java/de/entikore/cyclopenten/ui/screen/game/GameViewModelTest.kt
@@ -1,7 +1,6 @@
 package de.entikore.cyclopenten.ui.screen.game
 
 import androidx.lifecycle.SavedStateHandle
-import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.filters.SmallTest
 import com.google.common.truth.Truth.assertThat
 import de.entikore.cyclopenten.GoodUnitTestData
@@ -18,7 +17,6 @@ import de.entikore.cyclopenten.ui.theme.ColorTheme
 import de.entikore.cyclopenten.util.Constants.SCORE_INCREASE_EASY_DIFF
 import de.entikore.cyclopenten.util.Constants.SCORE_INCREASE_HARD_DIFF
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -66,9 +64,11 @@ class GameViewModelTest {
 
         // soundEffectPreferenceUseCase gets invoked on viewmodel init
         mainCoroutineRule.launch {
-            `when`(soundEffectPreferenceUseCase.invoke()).thenReturn(flow {
-                UserPreferences(musicOn = false, soundEffectOn = false)
-            })
+            `when`(soundEffectPreferenceUseCase.invoke()).thenReturn(
+                flow {
+                    UserPreferences(musicOn = false, soundEffectOn = false)
+                }
+            )
         }
 
         viewModel = GameViewModel(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("org.jetbrains.kotlin.android") version "1.8.10" apply false
-    id("com.android.application") version "8.0.0" apply false
-    id("com.android.library") version "8.0.0" apply false
+    id("com.android.application") version "8.0.2" apply false
+    id("com.android.library") version "8.0.2" apply false
     id("com.google.dagger.hilt.android") version "2.45" apply false
 }
 


### PR DESCRIPTION
Updated to Android Gradle Plugin 8.0.2.
Switching from kapt to ksp for moshi, as kapt support is deprecated. 
In other cases, kapt is still used, as e.g. hilt does not currently support ksp.
A few dependencies have been bumped.